### PR TITLE
fix: update iOS verify scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoHomeIndicator -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorHomeIndicator -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",


### PR DESCRIPTION
## What
- Update the iOS verify script to use the SwiftPM package scheme generated by Capacitor v8.

## Why
- The SwiftPM package/product was renamed to the generated Capacitor v8 name, so the old Xcode scheme no longer exists.

## How
- Point `verify:ios` at `CapgoCapacitorHomeIndicator`.

## Testing
- `bun run check:wiring`
- `bun run verify:ios`

## Not Tested
- Full release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS verification build configuration to reference the correct build scheme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-home-indicator/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->